### PR TITLE
Specify platform and processor for Bundle-NativeCode

### DIFF
--- a/plugins/com.naef.jnlua.linux-lua51/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.linux-lua51/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 0.9.1.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="[0.9.1,1.0.0)"
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=x86))
-Bundle-NativeCode: lib/libjnlua5.1.so ; lib/liblua5.1.so
+Bundle-NativeCode: lib/libjnlua5.1.so ; lib/liblua5.1.so; platform=linux; processor=x86
 Bundle-ClassPath: lib/,
   .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/com.naef.jnlua.linux-lua52/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.linux-lua52/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="1.0.3"
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=x86))
-Bundle-NativeCode: lib/libjnlua52.so ; lib/liblua52.so
+Bundle-NativeCode: lib/libjnlua52.so ; lib/liblua52.so; platform=linux; processor=x86
 Bundle-ClassPath: lib/,
   .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/com.naef.jnlua.linux64-lua51/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.linux64-lua51/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 0.9.1.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="[0.9.1,1.0.0)"
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=x86_64))
-Bundle-NativeCode: lib/libjnlua5.1.so ; lib/liblua5.1.so
+Bundle-NativeCode: lib/libjnlua5.1.so ; lib/liblua5.1.so; platform=linux; processor=x86-64
 Bundle-ClassPath: lib/,
   .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/com.naef.jnlua.linux64-lua52/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.linux64-lua52/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="1.0.3"
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=x86_64))
-Bundle-NativeCode: lib/libjnlua52.so; lib/liblua52.so
+Bundle-NativeCode: lib/libjnlua52.so; lib/liblua52.so; platform=linux; processor=x86-64
 Bundle-ClassPath: lib/,
   .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/com.naef.jnlua.macosx-lua51/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.macosx-lua51/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 0.9.1.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="[0.9.1,1.0.0)"
 Eclipse-PlatformFilter: (&(osgi.os=macosx)(osgi.arch=x86_64))
-Bundle-NativeCode: lib/libjnlua5.1.jnilib; lib/liblua5.1.jnilib
+Bundle-NativeCode: lib/libjnlua5.1.jnilib; lib/liblua5.1.jnilib; platform=macos; processor=x86-64
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/com.naef.jnlua.macosx-lua52/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.macosx-lua52/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="1.0.3"
 Eclipse-PlatformFilter: (&(osgi.os=macosx)(osgi.arch=x86_64))
-Bundle-NativeCode: lib/libjnlua52.dylib; lib/liblua52.dylib
+Bundle-NativeCode: lib/libjnlua52.dylib; lib/liblua52.dylib; platform=macos; processor=x86-64
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/com.naef.jnlua.windows-lua51/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.windows-lua51/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 0.9.1.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="[0.9.1,1.0.0)"
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86))
-Bundle-NativeCode: lib/lua5.1.dll ; lib/jnlua5.1.dll
+Bundle-NativeCode: lib/lua5.1.dll ; lib/jnlua5.1.dll; platform=win32; processor=x86
 Bundle-ClassPath: lib/,
   .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/com.naef.jnlua.windows-lua52/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.windows-lua52/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="1.0.3"
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86))
-Bundle-NativeCode: lib/lua52.dll ; lib/jnlua52.dll
+Bundle-NativeCode: lib/lua52.dll ; lib/jnlua52.dll; platform=win32; processor=x86
 Bundle-ClassPath: lib/,
   .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/com.naef.jnlua.windows64-lua51/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.windows64-lua51/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 0.9.1.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="[0.9.1,1.0.0)"
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86_64))
-Bundle-NativeCode: lib/lua5.1.dll ; lib/jnlua5.1.dll
+Bundle-NativeCode: lib/lua5.1.dll ; lib/jnlua5.1.dll; platform=win32; processor=x86-64
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/com.naef.jnlua.windows64-lua52/META-INF/MANIFEST.MF
+++ b/plugins/com.naef.jnlua.windows64-lua52/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: com.naef.jnlua;bundle-version="1.0.3"
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86_64))
-Bundle-NativeCode: lib/lua52.dll ; lib/jnlua52.dll
+Bundle-NativeCode: lib/lua52.dll ; lib/jnlua52.dll; platform=win32; processor=x86-64
 Bundle-ClassPath: .,
  lib/
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6


### PR DESCRIPTION
The OSGi R4 specification seems to imply that platform and processor
specifications are required when specifying native code. When attempting
to use these bundles under the apache felix osgi runtime a bundle resolution
error occurs unless the platform/processor are specified.
